### PR TITLE
Pin to specific kapitan version

### DIFF
--- a/hooks/kapitan-compile.sh
+++ b/hooks/kapitan-compile.sh
@@ -2,5 +2,5 @@
 
 set -e
 
-docker run -t --rm -v $(pwd):/src:delegated deepmind/kapitan compile
+docker run -t --rm -v "$(pwd)":/src:delegated deepmind/kapitan:0.26.1 compile
 


### PR DESCRIPTION
Kapitan doesn't guarantee that the `latest` tag is working, we should ping to specific version. I'm confirming this in the #kapitan slack channel.

Also adding the double quotes as suggested by shellcheck.