### PR TITLE
add(lint,args): shell linters and args support

### DIFF
--- a/.editconfig
+++ b/.editconfig
@@ -1,0 +1,10 @@
+[*.sh]
+# like -i=4
+indent_style = space
+indent_size = 4
+
+shell_variant      = posix # like -ln=posix
+binary_next_line   = true  # like -bn
+switch_case_indent = true  # like -ci
+space_redirects    = true  # like -sr
+keep_padding       = true  # like -kp

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,3 +5,8 @@ repos:
   - id: trailing-whitespace
   - id: end-of-file-fixer
   - id: check-yaml
+- repo: https://github.com/jumanjihouse/pre-commit-hooks
+  rev: 2.0.1
+  hooks:
+  - id: shellcheck
+  - id: shfmt

--- a/README.md
+++ b/README.md
@@ -6,3 +6,7 @@ A collection of pre-commit hooks for [https://github.com/pre-commit/pre-commit](
 
 - **kapitan-compile**: Compiles [Kapitan](https://kapitan.dev) templates
 
+## Development dependencies
+
+- [shellcheck](https://www.shellcheck.net/)
+- [shfmt](https://github.com/mvdan/sh)

--- a/hooks/kapitan-compile.sh
+++ b/hooks/kapitan-compile.sh
@@ -1,6 +1,6 @@
-#!/bin/bash
+#!/bin/sh
 
-set -e
+set -eu
 
-docker run -t --rm -v "$(pwd)":/src:delegated deepmind/kapitan:0.27.2 compile
-
+# shellcheck disable=SC2068
+docker run -t --rm -v "${PWD}":/src:delegated deepmind/kapitan:0.27.2 compile $@


### PR DESCRIPTION
Adding:
- shell linter and formatter
- args support in kapitan-compile hook

Changes:
- using more basic but universal `sh` instead of `bash` for hook's shell