### PR TITLE
Add support for KAPITAN_IMAGE environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,11 @@ A collection of pre-commit hooks for [https://github.com/pre-commit/pre-commit](
 
 ## Hooks
 
-- **kapitan-compile**: Compiles [Kapitan](https://kapitan.dev) templates
+### `kapitan-compile`
+
+Compiles [Kapitan](https://kapitan.dev) templates. Supports the `KAPITAN_IMAGE`
+environment variable which should be the docker image to use. Defaults to:
+`deepmind/kapitan:v0.29.5`.
 
 ## Development dependencies
 

--- a/hooks/kapitan-compile.sh
+++ b/hooks/kapitan-compile.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 
-set -eu
+set -eux
+
+KAPITAN_IMAGE="${KAPITAN_IMAGE:-deepmind/kapitan:v0.29.5}"
 
 # shellcheck disable=SC2068
-docker run -t --rm -v "${PWD}":/src:delegated deepmind/kapitan:0.27.2 compile $@
+docker run -t --rm -v "${PWD}":/src:delegated "${KAPITAN_IMAGE}" compile "$@"


### PR DESCRIPTION
# Summary

I was going to update the image again, but figured we can future proof it a little with `KAPITAN_IMAGE`.
Defaults to an upgraded version v0.29.5
